### PR TITLE
Fix potential crash with autoscope name conflict

### DIFF
--- a/lib/src/watch_it_state.dart
+++ b/lib/src/watch_it_state.dart
@@ -549,13 +549,14 @@ class _WatchItState {
 
   bool _scopeWasPushed = false;
   String? _scopeName;
+  static int _autoScopeCounter = 0;
 
   void pushScope(
       {void Function(GetIt getIt)? init,
       void Function()? dispose,
       bool isFinal = false}) {
     if (!_scopeWasPushed) {
-      _scopeName = 'AutoScope: ${DateTime.now().microsecondsSinceEpoch}';
+      _scopeName = 'AutoScope: ${_autoScopeCounter++}';
       GetIt.I.pushNewScope(
           dispose: dispose,
           init: init,


### PR DESCRIPTION
Uses a static counter for autoscope names instead of epoch microsecond as a fix for #37.