### PR TITLE
Gettin rid of static analysis warning

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -193,7 +193,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.5.1"
+    version: "1.6.0"
 sdks:
   dart: ">=3.5.0 <4.0.0"
   flutter: ">=3.0.0"

--- a/lib/src/watch_it_state.dart
+++ b/lib/src/watch_it_state.dart
@@ -399,7 +399,7 @@ class _WatchItState {
         watch.dispose();
         initialValue = preserveState && watch.lastValue!.hasData
             ? watch.lastValue!.data
-            : initialValueProvider?.call();
+            : initialValueProvider.call();
       }
     } else {
       /// In case futureProvider != null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
First of all, thank you very much for this amazing package. I am currently using it in a small project of mine and it works great!

When checking on pub.dev if there was a new version, I saw that the package only got 140/160 pub points.
The reason for this was a linter warning.
I opted for the proposed solution of the warning in a single line of code.

It is a small contribution to a great project.

Kind regards